### PR TITLE
fix/day3 image path

### DIFF
--- a/articles/day3-deviation-score.md
+++ b/articles/day3-deviation-score.md
@@ -27,11 +27,11 @@ Day 2 で導入した PoR・ΔE・grv の動的トラッキングは、意味の
 - Δt 正規化：turn 間隔のばらつきを 1 ステップ単位に統一
 
 ### 2. 値スケーリング
-PoR・ΔE・grv はスケールが異なるため、全て `min-max` 正規化で **0–1** に揃える。
-\[
-X_{\text{norm}} = \frac{X - X_{\min}}{X_{\max} - X_{\min}}
-\]
+PoR・ΔE・grv はスケールが異なるため、全て `min-max` 正規化で **0–1** に揃える
 
+$$
+X_{\text{norm}} = \frac{X - X_{\min}}{X_{\max} - X_{\min}}
+$$
 ### 3. スムージング
 - `ewm(span=3)` で平滑化しつつ  
 - PoR スパイクの急変を残すように `adjust=False` 設定  


### PR DESCRIPTION
- **fix: correct fig2 image path (Day3 article)**
- **fix: use absolute /images paths for Day3 figures**
- **fix: use absolute /images paths for Day3 figures**
- **fix: format PoR spike piece-wise formula with 7628 cases 7628**
- **fix: use 7628 block for min-max normalization formula**
