### PR TITLE
Add ChatCompletionSampler & smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+### Added
+- feat: ChatCompletionSampler utility and smoke tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![CI](https://github.com/Yuu6798/unconscious-gravity/actions/workflows/test.yml/badge.svg)](...)
+[![CI](https://github.com/Yuu6798/unconscious-gravity/actions/workflows/test.yml/badge.svg)](https://github.com/Yuu6798/unconscious-gravity/actions/workflows/test.yml)
+[![Diagnostics](https://github.com/Yuu6798/unconscious-gravity/actions/workflows/por_diagnostics.yml/badge.svg)](https://github.com/Yuu6798/unconscious-gravity/actions/workflows/por_diagnostics.yml)
 <!-- BEGIN_AUTO_README -->
 # Unconscious Gravity Hypothesis (UGHer)
 
@@ -152,4 +153,21 @@ GitHub: https://github.com/Yuu6798/unconscious-gravity
 
 For collaboration or questions:  
 Twitter (X): @kkoo6798kamo
+
+
+---
+
+## ChatCompletionSampler
+
+`ChatCompletionSampler` provides a small wrapper around the OpenAI Chat Completion API to fetch multiple candidate responses. It is used by experiments to gather diverse outputs for analysis.
+
+## Requirements
+
+This project depends on several Python packages including:
+
+- numpy
+- pandas
+- tqdm
+- transformers
+- openai
 

--- a/pyproject.toml.bak
+++ b/pyproject.toml.bak
@@ -10,6 +10,7 @@ dependencies = [
     "pandas",
     "tqdm",
     "transformers",
+    "openai",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.24
 pandas>=1.5
+openai>=1.0

--- a/src/unconscious_gravity_exp/chat_completion_sampler.py
+++ b/src/unconscious_gravity_exp/chat_completion_sampler.py
@@ -1,0 +1,22 @@
+"""Simple sampler for OpenAI chat completions."""
+
+from typing import List
+import openai
+
+
+class ChatCompletionSampler:
+    """Utility to sample multiple chat completions using the OpenAI API."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo") -> None:
+        """Initialize with target model name."""
+        self.model = model
+
+    def sample(self, prompt: str, n: int = 1) -> List[str]:
+        """Return ``n`` completions for ``prompt``."""
+        resp = openai.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            n=n,
+        )
+        return [choice.message.content for choice in resp.choices]
+

--- a/tests/smoke/test_smoke_full.py
+++ b/tests/smoke/test_smoke_full.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from ugher_exp.por_detector import detect_pors
+from models.por_formal_models import PoRModel
+
+
+def test_por_detection_fail(tmp_path):
+    df = pd.DataFrame({"cosine_shift": [0.1], "curr_resp": ["hello"]})
+    path = tmp_path / "input.parquet"
+    df.to_parquet(path)
+    result = detect_pors(str(path))
+    assert result["PoR_flag"].sum() == 0
+
+
+def test_low_grv_score():
+    grv = PoRModel.semantic_gravity(0.1, 0.05)
+    assert grv < 0.01
+


### PR DESCRIPTION
## Summary
- add a minimal ChatCompletionSampler utility
- add PoR failure and low gravity smoke tests
- document sampler usage and dependencies
- include new openai dependency and changelog entry

## Testing
- `python -m pytest -q tests/smoke/test_smoke_full.py` *(fails: No module named pytest)*