### PR TITLE
Fix tests import path

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-pythonpath = src
+pythonpath =
+    src
+    .

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,12 @@
-# enables package-level imports in tests
+"""Test package initialization."""
+
+import os
+import sys
+
+# Add project root and ``src`` to ``sys.path`` so tests can import local modules
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_DIR = os.path.join(ROOT_DIR, "src")
+
+for p in (ROOT_DIR, SRC_DIR):
+    if p not in sys.path:
+        sys.path.insert(0, p)


### PR DESCRIPTION
## Summary
- update pytest path configuration
- ensure project root is on `sys.path` for test imports

## Testing
- `python -m pytest -k noop`