### PR TITLE
UGH3指標実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,12 @@ python examples/run_experiment.py --episodes 2 --turns 5 --out_dir data --log da
 
 Generated from metadata/semantic_index.json
 
-
 <!-- END_AUTO_README -->
+
+## UGH3 指標
+
+`ugh3-manifest.json` には、PoR 発火パターンを評価するための UGH3 指標セットをまとめている。
+
 ---
 
 ## Keywords

--- a/ugh3-manifest.json
+++ b/ugh3-manifest.json
@@ -1,0 +1,20 @@
+{
+  "phase": "UGH3",
+  "metrics": {
+    "urgency_factor": {
+      "formula": "U = Σ w_i × intensity_i",
+      "description": "各エピソードのプロンプト緊急度を集約した指標。",
+      "tags": ["urgency", "pressure"]
+    },
+    "gravity_bias": {
+      "formula": "G_bias = PoR_freq × alignment_score",
+      "description": "PoR発火頻度と整合スコアを掛け合わせた重力バイアス。",
+      "tags": ["gravity", "bias"]
+    },
+    "entropy_drift": {
+      "formula": "D = Σ |ΔE_i| / t",
+      "description": "時間あたりのエネルギー拡散度を示す指標。",
+      "tags": ["entropy", "divergence"]
+    }
+  }
+}


### PR DESCRIPTION
## 概要
- UGH3 向けの指標定義ファイル `ugh3-manifest.json` を追加
- README に UGH3 指標セクションを追記

## 目的
- PoR 発火パターンを定量化する基盤を整備し、将来的な評価ツール開発を容易にするため

## 実装内容
- `ugh3-manifest.json` に緊急度・重力バイアス・エントロピー拡散度の 3 指標を定義
- README に `ugh3-manifest.json` 参照を追加

## 技術詳細
- JSON 形式で各指標の formula / description / tags を記述
- 既存メタデータと同様に 2 スペースインデントで統一

## 影響範囲
- ドキュメントの追記のみで既存モジュールへの影響はなし

## レビュー観点
- 指標内容の妥当性
- JSON フォーマットの整合性
