### PR TITLE
Add PoR-ΔE spec and design sketch

### DIFF
--- a/design_sketch.py
+++ b/design_sketch.py
@@ -1,0 +1,34 @@
+"""Design prototype for PoR/ΔE library."""
+
+def por_trigger(q, s, t, phi_C, D, theta=0.6):
+    """PoR firing decision.
+
+    Parameters
+    ----------
+    q : float
+        Question magnitude.
+    s : float
+        Semantic resonance.
+    t : float
+        Critical time value.
+    phi_C : float
+        Context resonance factor.
+    D : float
+        Dampening coefficient.
+    theta : float, optional
+        Activation threshold, by default 0.6.
+
+    Returns
+    -------
+    dict
+        Contains intermediate values and trigger boolean.
+    """
+    E_prime = q * s * t
+    score = E_prime * phi_C
+    triggered = (score * (1 - D)) > theta
+    return {"E_prime": E_prime, "score": score, "triggered": triggered}
+
+
+def deltae_score(E1, E2):
+    """ΔE (energy difference)."""
+    return E2 - E1

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,17 @@
+# PoR・ΔE OSS Library Specification Draft
+
+## Purpose
+- To make PoR trigger and ΔE score reproducible for anyone as a library
+
+## Core functions
+- por_trigger(q, s, t, phi_C, D): PoR firing decision
+- deltae_score(E1, E2): ΔE score calculation
+
+## I/O examples
+- por_trigger: input (q, s, t, phi_C, D) → output (bool, score value)
+- deltae_score: input (E1, E2) → output (ΔE value)
+
+## Reference formulas
+- E' = q × s × t
+- score = E' × φ_C
+- ΔE = E2 - E1


### PR DESCRIPTION
## Summary
- add initial PoR/ΔE library specification
- prototype library functions in design sketch

## Related Issues
- closes #

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] `python -m pytest` passes

## Testing
```bash
python -m pytest -q
# pytest not installed in environment
```