### PR TITLE
Add spec draft and design sketch

### DIFF
--- a/design_sketch.py
+++ b/design_sketch.py
@@ -1,0 +1,11 @@
+def por_trigger(q, s, t, phi_C, D, theta=0.6):
+    """PoR firing decision. Returns True/False based on the condition."""
+    E_prime = q * s * t
+    score = E_prime * phi_C
+    triggered = (score * (1 - D)) > theta
+    return {"E_prime": E_prime, "score": score, "triggered": triggered}
+
+
+def deltae_score(E1, E2):
+    """ΔE (energy change)"""
+    return E2 - E1

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,17 @@
+# PoR/ΔE OSS Library Specification Draft
+
+## Purpose
+- Provide a reproducible library for PoR trigger and ΔE scoring
+
+## Core Functions
+- por_trigger(q, s, t, phi_C, D): PoR firing decision
+- deltae_score(E1, E2): ΔE score calculation
+
+## I/O Examples
+- por_trigger: input (q, s, t, phi_C, D) → output (bool, score value)
+- deltae_score: input (E1, E2) → output (ΔE value)
+
+## Reference Formulas
+- E' = q × s × t
+- score = E' × φ_C
+- ΔE = E2 - E1


### PR DESCRIPTION
## Summary
- add initial `spec.md` draft for PoR/ΔE library
- provide `design_sketch.py` with simple prototype functions

## Testing
- `pytest -q test_sample.py` *(fails: command not found)*