### PR TITLE
docs: add canonical compatibility note with ugh-audit-core

### DIFF
--- a/CANONICAL_COMPATIBILITY.md
+++ b/CANONICAL_COMPATIBILITY.md
@@ -1,0 +1,21 @@
+# Canonical Compatibility
+
+This repository keeps PoR/ΔE/grv theory expressions as research artifacts.
+
+Operational scoring/verdict behavior is defined in:
+
+- `Yuu6798/ugh-audit-core/docs/canonical_metrics_contract.md`
+
+Positioning:
+
+- Here: `metric_mode="research_variant"` (theory-oriented formulas).
+- Production audit and verdict: `ugh-audit-core` operational contract.
+
+Guardrails:
+
+- Do not publish incompatible formulas as plain production `delta_e`.
+- Use explicit method labels when exporting metrics:
+  - `metric_mode`
+  - `delta_e_method`
+  - `por_method`
+  - `grv_method`


### PR DESCRIPTION
## Summary
- add `CANONICAL_COMPATIBILITY.md`
- keep PoR/ΔE/grv theory as research layer
- define `ugh-audit-core` as canonical operational scoring/verdict contract
- add naming/method guardrails for exported metrics

## Why
To preserve theory while ensuring production alignment and avoiding metric-name collisions.

## Scope
Documentation only (no runtime behavior change).