### PR TITLE
test: isolate dummy dialog output path from repository data

### DIFF
--- a/examples/dummy_dialog.py
+++ b/examples/dummy_dialog.py
@@ -1,39 +1,45 @@
 #!/usr/bin/env python3
-"""
-10件のダミー対話ターンを生成し、
-logger.append_log で Parquet ファイルに書き出すスモークテスト用スクリプト
-"""
+"""Generate a sample 10-turn dialog and store it as parquet."""
 
-import sys
-from pathlib import Path
+import argparse
 import random
+from pathlib import Path
 
-# プロジェクトの src フォルダをインポートパスに追加
-project_root = Path(__file__).resolve().parent.parent
-sys.path.append(str(project_root / "src"))
-
-from unconscious_gravity_exp.proxy_config import TurnLog
 from unconscious_gravity_exp.logger import append_log
+from unconscious_gravity_exp.proxy_config import TurnLog
 
-def main():
-    # 出力先ディレクトリとファイル名
-    data_dir = project_root / "data"
-    data_dir.mkdir(exist_ok=True)
-    out_file = data_dir / "sample_dialog.parquet"
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-    # 10件のダミーデータを逐次書き込み
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=PROJECT_ROOT / "data" / "sample_dialog.parquet",
+        help="Output parquet file path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    out_file = args.out
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+
     for i in range(1, 11):
         turn = TurnLog(
             TurnId=i,
-            Prompt=f"ユーザーの発話 {i}",
-            Response=f"AIの応答 {i}",
+            Prompt=f"User prompt {i}",
+            Response=f"AI response {i}",
             Q_self=random.random(),
             S_q=random.random(),
-            t_total=random.randint(50, 500),  # ミリ秒
-            M=random.random()
+            t_total=random.randint(50, 500),
+            M=random.random(),
         )
         append_log(turn, file=str(out_file))
-        print(f"[{i}] 書き込み完了 → {out_file}")
+        print(f"[{i}] wrote: {out_file}")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/dummy_dialog.py
+++ b/examples/dummy_dialog.py
@@ -3,12 +3,16 @@
 
 import argparse
 import random
+import sys
 from pathlib import Path
 
-from unconscious_gravity_exp.logger import append_log
-from unconscious_gravity_exp.proxy_config import TurnLog
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from unconscious_gravity_exp.logger import append_log  # noqa: E402
+from unconscious_gravity_exp.proxy_config import TurnLog  # noqa: E402
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,39 +3,26 @@ import sys
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
 from unconscious_gravity_exp.proxy_config import TurnLog
 
 PROJECT_ROOT = Path(__file__).parent.parent
 
-def test_dummy_dialog_creates_parquet(tmp_path, monkeypatch):
-    # プロジェクトルートに移動
-    monkeypatch.chdir(PROJECT_ROOT)
 
-    # 既存の出力をクリア
-    out_dir = PROJECT_ROOT / "data"
-    if out_dir.exists():
-        for p in out_dir.iterdir():
-            p.unlink()
-    else:
-        out_dir.mkdir()
+def test_dummy_dialog_creates_parquet(tmp_path):
+    parquet_path = tmp_path / "sample_dialog.parquet"
 
-    # dummy_dialog.py を実行
     result = subprocess.run(
-        [sys.executable, "examples/dummy_dialog.py"],
+        [sys.executable, "examples/dummy_dialog.py", "--out", str(parquet_path)],
+        cwd=PROJECT_ROOT,
         capture_output=True,
-        text=True
+        text=True,
     )
-    assert result.returncode == 0, f"dummy_dialog.py 実行失敗:\n{result.stderr}"
+    assert result.returncode == 0, f"dummy_dialog.py failed:\n{result.stderr}"
+    assert parquet_path.exists(), "sample_dialog.parquet was not created"
 
-    # Parquet ファイルの存在を確認
-    parquet_path = out_dir / "sample_dialog.parquet"
-    assert parquet_path.exists(), "sample_dialog.parquet が作成されていません"
-
-    # データを読み込み、行数とスキーマをチェック
     df = pd.read_parquet(parquet_path)
-    assert len(df) == 10, f"行数が10ではありません: {len(df)}"
+    assert len(df) == 10, f"Expected 10 rows, got {len(df)}"
 
     expected_cols = list(TurnLog.__annotations__.keys())
-    assert set(df.columns) == set(expected_cols), f"スキーマが一致しません: {df.columns.tolist()}"
+    assert set(df.columns) == set(expected_cols), f"Unexpected schema: {df.columns.tolist()}"


### PR DESCRIPTION
## Summary
- add `--out` option to `examples/dummy_dialog.py` so output path can be specified
- keep default behavior (`data/sample_dialog.parquet`) for manual usage
- update logger test to write into `tmp_path` and avoid deleting files under tracked `data/`

## Why
- running tests should not dirty the repository working tree
- this makes local iteration and CI behavior safer and more reproducible

## Validation
- `python -m pytest -q` (49 passed)
- `python -m ruff check examples/dummy_dialog.py tests/test_logger.py`